### PR TITLE
Fix/key of zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ A binary search tree with AVL balancing.
 
 I will be working to add different balancing techniques such as red black trees, scapegoat, and splay. Uses ES6 module system and can be used on the front end and for Node. It's 2017 why not write the module system in ES6. Every utility function, type, interface, and class are able to be imported from the module or as one object.
 
+## Previous Important Issues
+
+* Can not enter falsy keys.
+Version 1.0.6 fixed a small but important issue where keys could not be falsy values. All previous version have this issue. 
 
 ## Install
 

--- a/__tests__/Node.spec.ts
+++ b/__tests__/Node.spec.ts
@@ -1,6 +1,19 @@
 import { AVLTree } from "../src";
 
 describe("creating JSON from Tree", () => {
+    test("Insert ordered array no rebalance", () => {
+        const avl: AVLTree = new AVLTree({ unique: true });
+        const parsedJSON = [{ key: 27, value: ["a"]}, { key: 35, value: ["b"]}, { key: 22, value: ["c"]}, { key: 39, value: ["d"]}, { key: 25, value: ["d"]}, { key: 28, value: ["e"]}, { key: 0, value: ["f"]}, { key: 26, value: ["g"]}, { key: 1, value: ["h"]}];
+
+        for (const item of parsedJSON) {
+            avl.insert(item.key, item.value);
+        }
+        const json = JSON.parse(avl.tree.toJSON<AVLTree>());
+        const zoneOfTheEnders = avl.tree.search(0);
+        expect(zoneOfTheEnders).toEqual(expect.arrayContaining(["f"]));
+        expect(json).toEqual(expect.arrayContaining([{ key: 27, value: ["a"]}, { key: 35, value: ["b"]}, { key: 22, value: ["c"]}, { key: 39, value: ["d"]}, { key: 25, value: ["d"]}, { key: 28, value: ["e"]}, { key: 0, value: ["f"]}, { key: 26, value: ["g"]}, { key: 1, value: ["h"]}]));
+    });
+
     describe("AVL to JSON", () => {
         const avlTree: AVLTree = new AVLTree({ unique: true});
         expect(avlTree).toBeInstanceOf(AVLTree);

--- a/docs/classes/_avl_node_avl_.avlnode.html
+++ b/docs/classes/_avl_node_avl_.avlnode.html
@@ -183,7 +183,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L41">avl-node/avl.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L41">avl-node/avl.ts:41</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -216,7 +216,7 @@
 						<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#checkkeyequality">checkKeyEquality</a></p>
 						<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#checkkeyequality">checkKeyEquality</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L146">basic-node/node.ts:146</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L146">basic-node/node.ts:146</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -236,7 +236,7 @@
 						<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#checkvalueequality">checkValueEquality</a></p>
 						<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#checkvalueequality">checkValueEquality</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L153">basic-node/node.ts:153</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L153">basic-node/node.ts:153</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -256,7 +256,7 @@
 						<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#comparekeys">compareKeys</a></p>
 						<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#comparekeys">compareKeys</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L133">basic-node/node.ts:133</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L133">basic-node/node.ts:133</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -275,7 +275,7 @@
 						<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#comparevalues">compareValues</a></p>
 						<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#comparevalues">compareValues</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L139">basic-node/node.ts:139</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L139">basic-node/node.ts:139</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -293,7 +293,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_avl_node_avl_.iavlnode.html">IAVLNode</a>.<a href="../interfaces/_avl_node_avl_.iavlnode.html#height">height</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L29">avl-node/avl.ts:29</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L29">avl-node/avl.ts:29</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -315,7 +315,7 @@
 						<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#key">key</a></p>
 						<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#key">key</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L119">basic-node/node.ts:119</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L119">basic-node/node.ts:119</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -332,7 +332,7 @@
 						<p>Implementation of <a href="../interfaces/_avl_node_avl_.iavlnode.html">IAVLNode</a>.<a href="../interfaces/_avl_node_avl_.iavlnode.html#left">left</a></p>
 						<p>Overrides <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#left">left</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L37">avl-node/avl.ts:37</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L37">avl-node/avl.ts:37</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -348,7 +348,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#options">options</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L46">avl-node/avl.ts:46</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L46">avl-node/avl.ts:46</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -364,7 +364,7 @@
 						<p>Implementation of <a href="../interfaces/_avl_node_avl_.iavlnode.html">IAVLNode</a>.<a href="../interfaces/_avl_node_avl_.iavlnode.html#parent">parent</a></p>
 						<p>Overrides <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#parent">parent</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L41">avl-node/avl.ts:41</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L41">avl-node/avl.ts:41</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -381,7 +381,7 @@
 						<p>Implementation of <a href="../interfaces/_avl_node_avl_.iavlnode.html">IAVLNode</a>.<a href="../interfaces/_avl_node_avl_.iavlnode.html#right">right</a></p>
 						<p>Overrides <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#right">right</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L33">avl-node/avl.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L33">avl-node/avl.ts:33</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -398,7 +398,7 @@
 						<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#unique">unique</a></p>
 						<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#unique">unique</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L127">basic-node/node.ts:127</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L127">basic-node/node.ts:127</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -415,7 +415,7 @@
 						<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#value">value</a></p>
 						<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#value">value</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L123">basic-node/node.ts:123</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L123">basic-node/node.ts:123</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -438,7 +438,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_avl_node_avl_.iavlnode.html">IAVLNode</a>.<a href="../interfaces/_avl_node_avl_.iavlnode.html#_delete">_delete</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L195">avl-node/avl.ts:195</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L195">avl-node/avl.ts:195</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -473,7 +473,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_avl_node_avl_.iavlnode.html">IAVLNode</a>.<a href="../interfaces/_avl_node_avl_.iavlnode.html#_insert">_insert</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L142">avl-node/avl.ts:142</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L142">avl-node/avl.ts:142</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -506,7 +506,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_avl_node_avl_.iavlnode.html">IAVLNode</a>.<a href="../interfaces/_avl_node_avl_.iavlnode.html#_updatekey">_updateKey</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L352">avl-node/avl.ts:352</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L352">avl-node/avl.ts:352</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -539,7 +539,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L502">avl-node/avl.ts:502</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L501">avl-node/avl.ts:501</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -562,7 +562,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#checkallnodesfullfillcondition">checkAllNodesFullfillCondition</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L258">basic-node/node.ts:258</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L266">basic-node/node.ts:266</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -593,7 +593,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L512">avl-node/avl.ts:512</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L511">avl-node/avl.ts:511</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -615,7 +615,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L466">avl-node/avl.ts:466</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L465">avl-node/avl.ts:465</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -640,7 +640,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#checkinternalpointers">checkInternalPointers</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#checkinternalpointers">checkInternalPointers</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L305">basic-node/node.ts:305</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L313">basic-node/node.ts:313</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -665,7 +665,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#checkisnode">checkIsNode</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#checkisnode">checkIsNode</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L223">basic-node/node.ts:223</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L231">basic-node/node.ts:231</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -690,7 +690,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#checknodeordering">checkNodeOrdering</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#checknodeordering">checkNodeOrdering</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L277">basic-node/node.ts:277</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L285">basic-node/node.ts:285</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -714,7 +714,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_avl_node_avl_.iavlnode.html">IAVLNode</a>.<a href="../interfaces/_avl_node_avl_.iavlnode.html#checkisavlt">checkisAVLT</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L102">avl-node/avl.ts:102</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L102">avl-node/avl.ts:102</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -738,7 +738,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_avl_node_avl_.iavlnode.html">IAVLNode</a>.<a href="../interfaces/_avl_node_avl_.iavlnode.html#createleftchild">createLeftChild</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L77">avl-node/avl.ts:77</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L77">avl-node/avl.ts:77</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -767,7 +767,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_avl_node_avl_.iavlnode.html">IAVLNode</a>.<a href="../interfaces/_avl_node_avl_.iavlnode.html#createrightchild">createRightChild</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L90">avl-node/avl.ts:90</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L90">avl-node/avl.ts:90</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -796,7 +796,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_avl_node_avl_.iavlnode.html">IAVLNode</a>.<a href="../interfaces/_avl_node_avl_.iavlnode.html#createsimilar">createSimilar</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L63">avl-node/avl.ts:63</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L63">avl-node/avl.ts:63</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -826,7 +826,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#executeoneverynode">executeOnEveryNode</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#executeoneverynode">executeOnEveryNode</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L598">basic-node/node.ts:598</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L606">basic-node/node.ts:606</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -857,7 +857,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_avl_node_avl_.iavlnode.html">IAVLNode</a>.<a href="../interfaces/_avl_node_avl_.iavlnode.html#getavlnodefromkey">getAVLNodeFromKey</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L113">avl-node/avl.ts:113</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L113">avl-node/avl.ts:113</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -890,7 +890,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#getequalitybounds">getEqualityBounds</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#getequalitybounds">getEqualityBounds</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L401">basic-node/node.ts:401</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L409">basic-node/node.ts:409</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -921,7 +921,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#getlowerboundmatcher">getLowerBoundMatcher</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#getlowerboundmatcher">getLowerBoundMatcher</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L326">basic-node/node.ts:326</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L334">basic-node/node.ts:334</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -954,7 +954,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#getmaxkey">getMaxKey</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#getmaxkey">getMaxKey</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L207">basic-node/node.ts:207</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L215">basic-node/node.ts:215</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -978,7 +978,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#getmaxkeydescendant">getMaxKeyDescendant</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#getmaxkeydescendant">getMaxKeyDescendant</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L183">basic-node/node.ts:183</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L191">basic-node/node.ts:191</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1009,7 +1009,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#getminkey">getMinKey</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#getminkey">getMinKey</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L215">basic-node/node.ts:215</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L223">basic-node/node.ts:223</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1033,7 +1033,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#getminkeydescendant">getMinKeyDescendant</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#getminkeydescendant">getMinKeyDescendant</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L195">basic-node/node.ts:195</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L203">basic-node/node.ts:203</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1063,7 +1063,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#getnumberofkeys">getNumberOfKeys</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#getnumberofkeys">getNumberOfKeys</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L235">basic-node/node.ts:235</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L243">basic-node/node.ts:243</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1087,7 +1087,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#gettreeasarrayofarrays">getTreeAsArrayOfArrays</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#gettreeasarrayofarrays">getTreeAsArrayOfArrays</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L525">basic-node/node.ts:525</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L533">basic-node/node.ts:533</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1130,7 +1130,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#gettreeheight">getTreeHeight</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#gettreeheight">getTreeHeight</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L490">basic-node/node.ts:490</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L498">basic-node/node.ts:498</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1166,7 +1166,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#getupperboundmatcher">getUpperBoundMatcher</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#getupperboundmatcher">getUpperBoundMatcher</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L363">basic-node/node.ts:363</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L371">basic-node/node.ts:371</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1197,7 +1197,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L580">avl-node/avl.ts:580</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L579">avl-node/avl.ts:579</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1221,7 +1221,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L647">avl-node/avl.ts:647</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L646">avl-node/avl.ts:646</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1246,7 +1246,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#query">query</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#query">query</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L416">basic-node/node.ts:416</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L424">basic-node/node.ts:424</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1277,7 +1277,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L428">avl-node/avl.ts:428</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L428">avl-node/avl.ts:428</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1308,7 +1308,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_avl_node_avl_.iavlnode.html">IAVLNode</a>.<a href="../interfaces/_avl_node_avl_.iavlnode.html#returnthisavl">returnThisAVL</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L54">avl-node/avl.ts:54</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L54">avl-node/avl.ts:54</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1332,7 +1332,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#returnthisnode">returnThisNode</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#returnthisnode">returnThisNode</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L174">basic-node/node.ts:174</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L182">basic-node/node.ts:182</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1354,7 +1354,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L531">avl-node/avl.ts:531</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L530">avl-node/avl.ts:530</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1378,7 +1378,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L628">avl-node/avl.ts:628</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L627">avl-node/avl.ts:627</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1403,7 +1403,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#search">search</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#search">search</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L461">basic-node/node.ts:461</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L469">basic-node/node.ts:469</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1436,7 +1436,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#tojson">toJSON</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#tojson">toJSON</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L580">basic-node/node.ts:580</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L588">basic-node/node.ts:588</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/_avl_tree_avltree_.avltree.html
+++ b/docs/classes/_avl_tree_avltree_.avltree.html
@@ -183,7 +183,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="_avl_node_avl_.avlnode.html">AVLNode</a>.<a href="_avl_node_avl_.avlnode.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-tree/avlTree.ts#L19">avl-tree/avlTree.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-tree/avlTree.ts#L19">avl-tree/avlTree.ts:19</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -216,7 +216,7 @@
 						<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#checkkeyequality">checkKeyEquality</a></p>
 						<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#checkkeyequality">checkKeyEquality</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L146">basic-node/node.ts:146</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L146">basic-node/node.ts:146</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -236,7 +236,7 @@
 						<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#checkvalueequality">checkValueEquality</a></p>
 						<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#checkvalueequality">checkValueEquality</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L153">basic-node/node.ts:153</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L153">basic-node/node.ts:153</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -256,7 +256,7 @@
 						<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#comparekeys">compareKeys</a></p>
 						<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#comparekeys">compareKeys</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L133">basic-node/node.ts:133</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L133">basic-node/node.ts:133</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -275,7 +275,7 @@
 						<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#comparevalues">compareValues</a></p>
 						<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#comparevalues">compareValues</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L139">basic-node/node.ts:139</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L139">basic-node/node.ts:139</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -294,7 +294,7 @@
 						<p>Implementation of <a href="../interfaces/_avl_node_avl_.iavlnode.html">IAVLNode</a>.<a href="../interfaces/_avl_node_avl_.iavlnode.html#height">height</a></p>
 						<p>Inherited from <a href="_avl_node_avl_.avlnode.html">AVLNode</a>.<a href="_avl_node_avl_.avlnode.html#height">height</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L29">avl-node/avl.ts:29</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L29">avl-node/avl.ts:29</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -316,7 +316,7 @@
 						<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#key">key</a></p>
 						<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#key">key</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L119">basic-node/node.ts:119</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L119">basic-node/node.ts:119</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -334,7 +334,7 @@
 						<p>Inherited from <a href="_avl_node_avl_.avlnode.html">AVLNode</a>.<a href="_avl_node_avl_.avlnode.html#left">left</a></p>
 						<p>Overrides <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#left">left</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L37">avl-node/avl.ts:37</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L37">avl-node/avl.ts:37</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -350,7 +350,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="_avl_node_avl_.avlnode.html">AVLNode</a>.<a href="_avl_node_avl_.avlnode.html#options">options</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-tree/avlTree.ts#L25">avl-tree/avlTree.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-tree/avlTree.ts#L25">avl-tree/avlTree.ts:25</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -367,7 +367,7 @@
 						<p>Inherited from <a href="_avl_node_avl_.avlnode.html">AVLNode</a>.<a href="_avl_node_avl_.avlnode.html#parent">parent</a></p>
 						<p>Overrides <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#parent">parent</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L41">avl-node/avl.ts:41</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L41">avl-node/avl.ts:41</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -385,7 +385,7 @@
 						<p>Inherited from <a href="_avl_node_avl_.avlnode.html">AVLNode</a>.<a href="_avl_node_avl_.avlnode.html#right">right</a></p>
 						<p>Overrides <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#right">right</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L33">avl-node/avl.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L33">avl-node/avl.ts:33</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -401,7 +401,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_avl_tree_avltree_.iavltree.html">IAVLTree</a>.<a href="../interfaces/_avl_tree_avltree_.iavltree.html#tree">tree</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-tree/avlTree.ts#L19">avl-tree/avlTree.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-tree/avlTree.ts#L19">avl-tree/avlTree.ts:19</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -418,7 +418,7 @@
 						<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#unique">unique</a></p>
 						<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#unique">unique</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L127">basic-node/node.ts:127</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L127">basic-node/node.ts:127</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -435,7 +435,7 @@
 						<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#value">value</a></p>
 						<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#value">value</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L123">basic-node/node.ts:123</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L123">basic-node/node.ts:123</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -459,7 +459,7 @@
 								<p>Implementation of <a href="../interfaces/_avl_node_avl_.iavlnode.html">IAVLNode</a>.<a href="../interfaces/_avl_node_avl_.iavlnode.html#_delete">_delete</a></p>
 								<p>Inherited from <a href="_avl_node_avl_.avlnode.html">AVLNode</a>.<a href="_avl_node_avl_.avlnode.html#_delete">_delete</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L195">avl-node/avl.ts:195</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L195">avl-node/avl.ts:195</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -495,7 +495,7 @@
 								<p>Implementation of <a href="../interfaces/_avl_node_avl_.iavlnode.html">IAVLNode</a>.<a href="../interfaces/_avl_node_avl_.iavlnode.html#_insert">_insert</a></p>
 								<p>Inherited from <a href="_avl_node_avl_.avlnode.html">AVLNode</a>.<a href="_avl_node_avl_.avlnode.html#_insert">_insert</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L142">avl-node/avl.ts:142</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L142">avl-node/avl.ts:142</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -529,7 +529,7 @@
 								<p>Implementation of <a href="../interfaces/_avl_node_avl_.iavlnode.html">IAVLNode</a>.<a href="../interfaces/_avl_node_avl_.iavlnode.html#_updatekey">_updateKey</a></p>
 								<p>Inherited from <a href="_avl_node_avl_.avlnode.html">AVLNode</a>.<a href="_avl_node_avl_.avlnode.html#_updatekey">_updateKey</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L352">avl-node/avl.ts:352</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L352">avl-node/avl.ts:352</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -563,7 +563,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_avl_node_avl_.avlnode.html">AVLNode</a>.<a href="_avl_node_avl_.avlnode.html#balancefactor">balanceFactor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L502">avl-node/avl.ts:502</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L501">avl-node/avl.ts:501</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -586,7 +586,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#checkallnodesfullfillcondition">checkAllNodesFullfillCondition</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L258">basic-node/node.ts:258</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L266">basic-node/node.ts:266</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -618,7 +618,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_avl_node_avl_.avlnode.html">AVLNode</a>.<a href="_avl_node_avl_.avlnode.html#checkbalancefactors">checkBalanceFactors</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L512">avl-node/avl.ts:512</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L511">avl-node/avl.ts:511</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -641,7 +641,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_avl_node_avl_.avlnode.html">AVLNode</a>.<a href="_avl_node_avl_.avlnode.html#checkheightcorrect">checkHeightCorrect</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L466">avl-node/avl.ts:466</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L465">avl-node/avl.ts:465</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -666,7 +666,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#checkinternalpointers">checkInternalPointers</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#checkinternalpointers">checkInternalPointers</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L305">basic-node/node.ts:305</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L313">basic-node/node.ts:313</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -691,7 +691,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#checkisnode">checkIsNode</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#checkisnode">checkIsNode</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L223">basic-node/node.ts:223</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L231">basic-node/node.ts:231</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -716,7 +716,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#checknodeordering">checkNodeOrdering</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#checknodeordering">checkNodeOrdering</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L277">basic-node/node.ts:277</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L285">basic-node/node.ts:285</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -741,7 +741,7 @@
 								<p>Implementation of <a href="../interfaces/_avl_node_avl_.iavlnode.html">IAVLNode</a>.<a href="../interfaces/_avl_node_avl_.iavlnode.html#checkisavlt">checkisAVLT</a></p>
 								<p>Inherited from <a href="_avl_node_avl_.avlnode.html">AVLNode</a>.<a href="_avl_node_avl_.avlnode.html#checkisavlt">checkisAVLT</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L102">avl-node/avl.ts:102</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L102">avl-node/avl.ts:102</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -766,7 +766,7 @@
 								<p>Implementation of <a href="../interfaces/_avl_node_avl_.iavlnode.html">IAVLNode</a>.<a href="../interfaces/_avl_node_avl_.iavlnode.html#createleftchild">createLeftChild</a></p>
 								<p>Inherited from <a href="_avl_node_avl_.avlnode.html">AVLNode</a>.<a href="_avl_node_avl_.avlnode.html#createleftchild">createLeftChild</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L77">avl-node/avl.ts:77</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L77">avl-node/avl.ts:77</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -796,7 +796,7 @@
 								<p>Implementation of <a href="../interfaces/_avl_node_avl_.iavlnode.html">IAVLNode</a>.<a href="../interfaces/_avl_node_avl_.iavlnode.html#createrightchild">createRightChild</a></p>
 								<p>Inherited from <a href="_avl_node_avl_.avlnode.html">AVLNode</a>.<a href="_avl_node_avl_.avlnode.html#createrightchild">createRightChild</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L90">avl-node/avl.ts:90</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L90">avl-node/avl.ts:90</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -826,7 +826,7 @@
 								<p>Implementation of <a href="../interfaces/_avl_node_avl_.iavlnode.html">IAVLNode</a>.<a href="../interfaces/_avl_node_avl_.iavlnode.html#createsimilar">createSimilar</a></p>
 								<p>Inherited from <a href="_avl_node_avl_.avlnode.html">AVLNode</a>.<a href="_avl_node_avl_.avlnode.html#createsimilar">createSimilar</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L63">avl-node/avl.ts:63</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L63">avl-node/avl.ts:63</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -855,7 +855,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_avl_tree_avltree_.iavltree.html">IAVLTree</a>.<a href="../interfaces/_avl_tree_avltree_.iavltree.html#delete">delete</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-tree/avlTree.ts#L49">avl-tree/avlTree.ts:49</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-tree/avlTree.ts#L49">avl-tree/avlTree.ts:49</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -890,7 +890,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#executeoneverynode">executeOnEveryNode</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#executeoneverynode">executeOnEveryNode</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L598">basic-node/node.ts:598</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L606">basic-node/node.ts:606</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -922,7 +922,7 @@
 								<p>Implementation of <a href="../interfaces/_avl_node_avl_.iavlnode.html">IAVLNode</a>.<a href="../interfaces/_avl_node_avl_.iavlnode.html#getavlnodefromkey">getAVLNodeFromKey</a></p>
 								<p>Inherited from <a href="_avl_node_avl_.avlnode.html">AVLNode</a>.<a href="_avl_node_avl_.avlnode.html#getavlnodefromkey">getAVLNodeFromKey</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L113">avl-node/avl.ts:113</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L113">avl-node/avl.ts:113</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -955,7 +955,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#getequalitybounds">getEqualityBounds</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#getequalitybounds">getEqualityBounds</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L401">basic-node/node.ts:401</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L409">basic-node/node.ts:409</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -986,7 +986,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#getlowerboundmatcher">getLowerBoundMatcher</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#getlowerboundmatcher">getLowerBoundMatcher</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L326">basic-node/node.ts:326</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L334">basic-node/node.ts:334</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1019,7 +1019,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#getmaxkey">getMaxKey</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#getmaxkey">getMaxKey</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L207">basic-node/node.ts:207</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L215">basic-node/node.ts:215</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1043,7 +1043,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#getmaxkeydescendant">getMaxKeyDescendant</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#getmaxkeydescendant">getMaxKeyDescendant</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L183">basic-node/node.ts:183</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L191">basic-node/node.ts:191</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1074,7 +1074,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#getminkey">getMinKey</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#getminkey">getMinKey</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L215">basic-node/node.ts:215</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L223">basic-node/node.ts:223</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1098,7 +1098,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#getminkeydescendant">getMinKeyDescendant</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#getminkeydescendant">getMinKeyDescendant</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L195">basic-node/node.ts:195</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L203">basic-node/node.ts:203</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1128,7 +1128,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#getnumberofkeys">getNumberOfKeys</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#getnumberofkeys">getNumberOfKeys</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L235">basic-node/node.ts:235</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L243">basic-node/node.ts:243</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1152,7 +1152,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#gettreeasarrayofarrays">getTreeAsArrayOfArrays</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#gettreeasarrayofarrays">getTreeAsArrayOfArrays</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L525">basic-node/node.ts:525</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L533">basic-node/node.ts:533</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1195,7 +1195,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#gettreeheight">getTreeHeight</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#gettreeheight">getTreeHeight</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L490">basic-node/node.ts:490</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L498">basic-node/node.ts:498</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1231,7 +1231,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#getupperboundmatcher">getUpperBoundMatcher</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#getupperboundmatcher">getUpperBoundMatcher</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L363">basic-node/node.ts:363</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L371">basic-node/node.ts:371</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1263,7 +1263,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_avl_tree_avltree_.iavltree.html">IAVLTree</a>.<a href="../interfaces/_avl_tree_avltree_.iavltree.html#insert">insert</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-tree/avlTree.ts#L35">avl-tree/avlTree.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-tree/avlTree.ts#L35">avl-tree/avlTree.ts:35</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1297,7 +1297,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_avl_node_avl_.avlnode.html">AVLNode</a>.<a href="_avl_node_avl_.avlnode.html#leftrotation">leftRotation</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L580">avl-node/avl.ts:580</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L579">avl-node/avl.ts:579</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1322,7 +1322,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_avl_node_avl_.avlnode.html">AVLNode</a>.<a href="_avl_node_avl_.avlnode.html#lefttoosmall">leftTooSmall</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L647">avl-node/avl.ts:647</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L646">avl-node/avl.ts:646</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1347,7 +1347,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#query">query</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#query">query</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L416">basic-node/node.ts:416</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L424">basic-node/node.ts:424</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1379,7 +1379,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_avl_node_avl_.avlnode.html">AVLNode</a>.<a href="_avl_node_avl_.avlnode.html#rebalancealongpath">rebalanceAlongPath</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L428">avl-node/avl.ts:428</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L428">avl-node/avl.ts:428</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1411,7 +1411,7 @@
 								<p>Implementation of <a href="../interfaces/_avl_node_avl_.iavlnode.html">IAVLNode</a>.<a href="../interfaces/_avl_node_avl_.iavlnode.html#returnthisavl">returnThisAVL</a></p>
 								<p>Inherited from <a href="_avl_node_avl_.avlnode.html">AVLNode</a>.<a href="_avl_node_avl_.avlnode.html#returnthisavl">returnThisAVL</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L54">avl-node/avl.ts:54</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L54">avl-node/avl.ts:54</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1435,7 +1435,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#returnthisnode">returnThisNode</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#returnthisnode">returnThisNode</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L174">basic-node/node.ts:174</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L182">basic-node/node.ts:182</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1458,7 +1458,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_avl_node_avl_.avlnode.html">AVLNode</a>.<a href="_avl_node_avl_.avlnode.html#rightrotation">rightRotation</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L531">avl-node/avl.ts:531</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L530">avl-node/avl.ts:530</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1483,7 +1483,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_avl_node_avl_.avlnode.html">AVLNode</a>.<a href="_avl_node_avl_.avlnode.html#righttoosmall">rightTooSmall</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L628">avl-node/avl.ts:628</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L627">avl-node/avl.ts:627</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1508,7 +1508,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#search">search</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#search">search</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L461">basic-node/node.ts:461</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L469">basic-node/node.ts:469</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1541,7 +1541,7 @@
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#tojson">toJSON</a></p>
 								<p>Inherited from <a href="_basic_node_node_.node.html">Node</a>.<a href="_basic_node_node_.node.html#tojson">toJSON</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L580">basic-node/node.ts:580</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L588">basic-node/node.ts:588</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1571,7 +1571,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_avl_tree_avltree_.iavltree.html">IAVLTree</a>.<a href="../interfaces/_avl_tree_avltree_.iavltree.html#updatekey">updateKey</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-tree/avlTree.ts#L58">avl-tree/avlTree.ts:58</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-tree/avlTree.ts#L58">avl-tree/avlTree.ts:58</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/_basic_node_node_.node.html
+++ b/docs/classes/_basic_node_node_.node.html
@@ -166,7 +166,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L153">basic-node/node.ts:153</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L153">basic-node/node.ts:153</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -198,7 +198,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#checkkeyequality">checkKeyEquality</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L146">basic-node/node.ts:146</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L146">basic-node/node.ts:146</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -217,7 +217,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#checkvalueequality">checkValueEquality</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L153">basic-node/node.ts:153</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L153">basic-node/node.ts:153</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -236,7 +236,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#comparekeys">compareKeys</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L133">basic-node/node.ts:133</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L133">basic-node/node.ts:133</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -254,7 +254,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#comparevalues">compareValues</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L139">basic-node/node.ts:139</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L139">basic-node/node.ts:139</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -272,7 +272,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#key">key</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L119">basic-node/node.ts:119</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L119">basic-node/node.ts:119</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -288,7 +288,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#left">left</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L106">basic-node/node.ts:106</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L106">basic-node/node.ts:106</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -308,7 +308,7 @@
 					<div class="tsd-signature tsd-kind-icon">options<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_basic_node_node_.inodeconstructor.html" class="tsd-signature-type">INodeConstructor</a><span class="tsd-signature-symbol">&lt;</span><a href="_basic_node_node_.node.html" class="tsd-signature-type">Node</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L159">basic-node/node.ts:159</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L159">basic-node/node.ts:159</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -323,7 +323,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#parent">parent</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L115">basic-node/node.ts:115</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L115">basic-node/node.ts:115</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -339,7 +339,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#right">right</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L111">basic-node/node.ts:111</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L111">basic-node/node.ts:111</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -360,7 +360,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#unique">unique</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L127">basic-node/node.ts:127</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L127">basic-node/node.ts:127</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -376,7 +376,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#value">value</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L123">basic-node/node.ts:123</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L123">basic-node/node.ts:123</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -398,7 +398,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L258">basic-node/node.ts:258</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L266">basic-node/node.ts:266</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -430,7 +430,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#checkinternalpointers">checkInternalPointers</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L305">basic-node/node.ts:305</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L313">basic-node/node.ts:313</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -454,7 +454,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#checkisnode">checkIsNode</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L223">basic-node/node.ts:223</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L231">basic-node/node.ts:231</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -478,7 +478,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#checknodeordering">checkNodeOrdering</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L277">basic-node/node.ts:277</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L285">basic-node/node.ts:285</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -502,7 +502,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#executeoneverynode">executeOnEveryNode</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L598">basic-node/node.ts:598</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L606">basic-node/node.ts:606</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -533,7 +533,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#getequalitybounds">getEqualityBounds</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L401">basic-node/node.ts:401</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L409">basic-node/node.ts:409</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -563,7 +563,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#getlowerboundmatcher">getLowerBoundMatcher</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L326">basic-node/node.ts:326</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L334">basic-node/node.ts:334</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -595,7 +595,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#getmaxkey">getMaxKey</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L207">basic-node/node.ts:207</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L215">basic-node/node.ts:215</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -618,7 +618,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#getmaxkeydescendant">getMaxKeyDescendant</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L183">basic-node/node.ts:183</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L191">basic-node/node.ts:191</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -648,7 +648,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#getminkey">getMinKey</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L215">basic-node/node.ts:215</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L223">basic-node/node.ts:223</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -671,7 +671,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#getminkeydescendant">getMinKeyDescendant</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L195">basic-node/node.ts:195</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L203">basic-node/node.ts:203</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -700,7 +700,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#getnumberofkeys">getNumberOfKeys</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L235">basic-node/node.ts:235</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L243">basic-node/node.ts:243</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -723,7 +723,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#gettreeasarrayofarrays">getTreeAsArrayOfArrays</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L525">basic-node/node.ts:525</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L533">basic-node/node.ts:533</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -765,7 +765,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#gettreeheight">getTreeHeight</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L490">basic-node/node.ts:490</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L498">basic-node/node.ts:498</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -800,7 +800,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#getupperboundmatcher">getUpperBoundMatcher</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L363">basic-node/node.ts:363</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L371">basic-node/node.ts:371</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -832,7 +832,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#query">query</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L416">basic-node/node.ts:416</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L424">basic-node/node.ts:424</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -864,7 +864,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#returnthisnode">returnThisNode</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L174">basic-node/node.ts:174</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L182">basic-node/node.ts:182</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -887,7 +887,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#search">search</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L461">basic-node/node.ts:461</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L469">basic-node/node.ts:469</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -919,7 +919,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_basic_node_node_.inode.html">INode</a>.<a href="../interfaces/_basic_node_node_.inode.html#tojson">toJSON</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L580">basic-node/node.ts:580</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L588">basic-node/node.ts:588</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/_avl_node_avl_.iavlnode.html
+++ b/docs/interfaces/_avl_node_avl_.iavlnode.html
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L5">avl-node/avl.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L5">avl-node/avl.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">left<span class="tsd-signature-symbol">:</span> <a href="../classes/_avl_node_avl_.avlnode.html" class="tsd-signature-type">AVLNode</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L7">avl-node/avl.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L7">avl-node/avl.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">parent<span class="tsd-signature-symbol">:</span> <a href="../classes/_avl_node_avl_.avlnode.html" class="tsd-signature-type">AVLNode</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L8">avl-node/avl.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L8">avl-node/avl.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -150,7 +150,7 @@
 					<div class="tsd-signature tsd-kind-icon">right<span class="tsd-signature-symbol">:</span> <a href="../classes/_avl_node_avl_.avlnode.html" class="tsd-signature-type">AVLNode</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L6">avl-node/avl.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L6">avl-node/avl.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -167,7 +167,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L17">avl-node/avl.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L17">avl-node/avl.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -193,7 +193,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L16">avl-node/avl.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L16">avl-node/avl.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -219,7 +219,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L18">avl-node/avl.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L18">avl-node/avl.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -245,7 +245,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L14">avl-node/avl.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L14">avl-node/avl.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -262,7 +262,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L12">avl-node/avl.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L12">avl-node/avl.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -285,7 +285,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L13">avl-node/avl.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L13">avl-node/avl.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -308,7 +308,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L11">avl-node/avl.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L11">avl-node/avl.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -331,7 +331,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L15">avl-node/avl.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L15">avl-node/avl.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -357,7 +357,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-node/avl.ts#L10">avl-node/avl.ts:10</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-node/avl.ts#L10">avl-node/avl.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">this</span></h4>

--- a/docs/interfaces/_avl_tree_avltree_.iavltree.html
+++ b/docs/interfaces/_avl_tree_avltree_.iavltree.html
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">tree<span class="tsd-signature-symbol">:</span> <a href="../classes/_avl_node_avl_.avlnode.html" class="tsd-signature-type">AVLNode</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-tree/avlTree.ts#L5">avl-tree/avlTree.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-tree/avlTree.ts#L5">avl-tree/avlTree.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -127,7 +127,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-tree/avlTree.ts#L8">avl-tree/avlTree.ts:8</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-tree/avlTree.ts#L8">avl-tree/avlTree.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -153,7 +153,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-tree/avlTree.ts#L7">avl-tree/avlTree.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-tree/avlTree.ts#L7">avl-tree/avlTree.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -179,7 +179,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/avl-tree/avlTree.ts#L9">avl-tree/avlTree.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/avl-tree/avlTree.ts#L9">avl-tree/avlTree.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/_basic_node_node_.iallqueary.html
+++ b/docs/interfaces/_basic_node_node_.iallqueary.html
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">$gt<span class="tsd-signature-symbol">:</span> <a href="../modules/_basic_node_node_.html#asndbs" class="tsd-signature-type">ASNDBS</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L46">basic-node/node.ts:46</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L46">basic-node/node.ts:46</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -117,7 +117,7 @@
 					<div class="tsd-signature tsd-kind-icon">$gte<span class="tsd-signature-symbol">:</span> <a href="../modules/_basic_node_node_.html#asndbs" class="tsd-signature-type">ASNDBS</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L47">basic-node/node.ts:47</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L47">basic-node/node.ts:47</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">$lt<span class="tsd-signature-symbol">:</span> <a href="../modules/_basic_node_node_.html#asndbs" class="tsd-signature-type">ASNDBS</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L48">basic-node/node.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L48">basic-node/node.ts:48</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -137,7 +137,7 @@
 					<div class="tsd-signature tsd-kind-icon">$lte<span class="tsd-signature-symbol">:</span> <a href="../modules/_basic_node_node_.html#asndbs" class="tsd-signature-type">ASNDBS</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L49">basic-node/node.ts:49</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L49">basic-node/node.ts:49</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">$ne<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L50">basic-node/node.ts:50</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L50">basic-node/node.ts:50</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_basic_node_node_.igreatquery.html
+++ b/docs/interfaces/_basic_node_node_.igreatquery.html
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">$gt<span class="tsd-signature-symbol">:</span> <a href="../modules/_basic_node_node_.html#asndbs" class="tsd-signature-type">ASNDBS</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L32">basic-node/node.ts:32</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L32">basic-node/node.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">$gte<span class="tsd-signature-symbol">:</span> <a href="../modules/_basic_node_node_.html#asndbs" class="tsd-signature-type">ASNDBS</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L33">basic-node/node.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L33">basic-node/node.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_basic_node_node_.ilessqueary.html
+++ b/docs/interfaces/_basic_node_node_.ilessqueary.html
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">$lt<span class="tsd-signature-symbol">:</span> <a href="../modules/_basic_node_node_.html#asndbs" class="tsd-signature-type">ASNDBS</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L37">basic-node/node.ts:37</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L37">basic-node/node.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">$lte<span class="tsd-signature-symbol">:</span> <a href="../modules/_basic_node_node_.html#asndbs" class="tsd-signature-type">ASNDBS</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L38">basic-node/node.ts:38</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L38">basic-node/node.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_basic_node_node_.inequery.html
+++ b/docs/interfaces/_basic_node_node_.inequery.html
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">$ne<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L42">basic-node/node.ts:42</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L42">basic-node/node.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_basic_node_node_.inode.html
+++ b/docs/interfaces/_basic_node_node_.inode.html
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">check<wbr>Key<wbr>Equality<span class="tsd-signature-symbol">:</span> <a href="_basic_node_node_.inode.html#checkkeyequality" class="tsd-signature-type">checkKeyEquality</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L74">basic-node/node.ts:74</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L74">basic-node/node.ts:74</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">check<wbr>Value<wbr>Equality<span class="tsd-signature-symbol">:</span> <a href="_basic_node_node_.inode.html#checkvalueequality" class="tsd-signature-type">checkValueEquality</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L75">basic-node/node.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L75">basic-node/node.ts:75</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">compare<wbr>Keys<span class="tsd-signature-symbol">:</span> <a href="_basic_node_node_.inode.html#comparekeys" class="tsd-signature-type">compareKeys</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L72">basic-node/node.ts:72</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L72">basic-node/node.ts:72</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">compare<wbr>Values<span class="tsd-signature-symbol">:</span> <a href="_basic_node_node_.inode.html#comparevalues" class="tsd-signature-type">compareValues</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L73">basic-node/node.ts:73</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L73">basic-node/node.ts:73</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">key<span class="tsd-signature-symbol">:</span> <a href="../modules/_basic_node_node_.html#asndbs" class="tsd-signature-type">ASNDBS</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L69">basic-node/node.ts:69</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L69">basic-node/node.ts:69</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -195,7 +195,7 @@
 					<div class="tsd-signature tsd-kind-icon">left<span class="tsd-signature-symbol">:</span> <a href="../classes/_basic_node_node_.node.html" class="tsd-signature-type">Node</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L66">basic-node/node.ts:66</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L66">basic-node/node.ts:66</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -205,7 +205,7 @@
 					<div class="tsd-signature tsd-kind-icon">parent<span class="tsd-signature-symbol">:</span> <a href="../classes/_basic_node_node_.node.html" class="tsd-signature-type">Node</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L68">basic-node/node.ts:68</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L68">basic-node/node.ts:68</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -215,7 +215,7 @@
 					<div class="tsd-signature tsd-kind-icon">right<span class="tsd-signature-symbol">:</span> <a href="../classes/_basic_node_node_.node.html" class="tsd-signature-type">Node</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L67">basic-node/node.ts:67</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L67">basic-node/node.ts:67</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -225,7 +225,7 @@
 					<div class="tsd-signature tsd-kind-icon">unique<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L71">basic-node/node.ts:71</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L71">basic-node/node.ts:71</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -235,7 +235,7 @@
 					<div class="tsd-signature tsd-kind-icon">value<span class="tsd-signature-symbol">:</span> <a href="../modules/_basic_node_node_.html#sndbsa" class="tsd-signature-type">SNDBSA</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L70">basic-node/node.ts:70</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L70">basic-node/node.ts:70</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -252,7 +252,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L84">basic-node/node.ts:84</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L84">basic-node/node.ts:84</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -281,7 +281,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L86">basic-node/node.ts:86</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L86">basic-node/node.ts:86</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -298,7 +298,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L82">basic-node/node.ts:82</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L82">basic-node/node.ts:82</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -315,7 +315,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L85">basic-node/node.ts:85</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L85">basic-node/node.ts:85</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -332,7 +332,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L95">basic-node/node.ts:95</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L95">basic-node/node.ts:95</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -355,7 +355,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L89">basic-node/node.ts:89</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L89">basic-node/node.ts:89</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -378,7 +378,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L87">basic-node/node.ts:87</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L87">basic-node/node.ts:87</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -401,7 +401,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L80">basic-node/node.ts:80</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L80">basic-node/node.ts:80</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -424,7 +424,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L78">basic-node/node.ts:78</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L78">basic-node/node.ts:78</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -447,7 +447,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L81">basic-node/node.ts:81</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L81">basic-node/node.ts:81</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -470,7 +470,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L79">basic-node/node.ts:79</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L79">basic-node/node.ts:79</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -493,7 +493,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L83">basic-node/node.ts:83</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L83">basic-node/node.ts:83</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -510,7 +510,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L93">basic-node/node.ts:93</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L93">basic-node/node.ts:93</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -533,7 +533,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L92">basic-node/node.ts:92</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L92">basic-node/node.ts:92</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -562,7 +562,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L88">basic-node/node.ts:88</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L88">basic-node/node.ts:88</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -585,7 +585,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L90">basic-node/node.ts:90</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L90">basic-node/node.ts:90</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -608,7 +608,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L77">basic-node/node.ts:77</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L77">basic-node/node.ts:77</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">this</span></h4>
@@ -625,7 +625,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L91">basic-node/node.ts:91</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L91">basic-node/node.ts:91</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -648,7 +648,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L94">basic-node/node.ts:94</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L94">basic-node/node.ts:94</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/docs/interfaces/_basic_node_node_.inodeconstructor.html
+++ b/docs/interfaces/_basic_node_node_.inodeconstructor.html
@@ -118,7 +118,7 @@
 					<div class="tsd-signature tsd-kind-icon">check<wbr>Key<wbr>Equality<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L61">basic-node/node.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L61">basic-node/node.ts:61</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -128,7 +128,7 @@
 					<div class="tsd-signature tsd-kind-icon">check<wbr>Value<wbr>Equality<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L62">basic-node/node.ts:62</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L62">basic-node/node.ts:62</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -138,7 +138,7 @@
 					<div class="tsd-signature tsd-kind-icon">compare<wbr>Keys<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L59">basic-node/node.ts:59</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L59">basic-node/node.ts:59</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -148,7 +148,7 @@
 					<div class="tsd-signature tsd-kind-icon">compare<wbr>Values<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L60">basic-node/node.ts:60</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L60">basic-node/node.ts:60</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -158,7 +158,7 @@
 					<div class="tsd-signature tsd-kind-icon">key<span class="tsd-signature-symbol">:</span> <a href="../modules/_basic_node_node_.html#asndbs" class="tsd-signature-type">ASNDBS</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L56">basic-node/node.ts:56</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L56">basic-node/node.ts:56</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -168,7 +168,7 @@
 					<div class="tsd-signature tsd-kind-icon">parent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L55">basic-node/node.ts:55</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L55">basic-node/node.ts:55</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -178,7 +178,7 @@
 					<div class="tsd-signature tsd-kind-icon">unique<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">true</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L58">basic-node/node.ts:58</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L58">basic-node/node.ts:58</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -188,7 +188,7 @@
 					<div class="tsd-signature tsd-kind-icon">value<span class="tsd-signature-symbol">:</span> <a href="../modules/_basic_node_node_.html#sndbsa" class="tsd-signature-type">SNDBSA</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L57">basic-node/node.ts:57</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L57">basic-node/node.ts:57</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/_basic_node_node_.html
+++ b/docs/modules/_basic_node_node_.html
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">ASNDBS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Date</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Date</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L9">basic-node/node.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L9">basic-node/node.ts:9</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">SNDBSA<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">__type</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Date</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L7">basic-node/node.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L7">basic-node/node.ts:7</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">check<wbr>Key<wbr>Equality<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L26">basic-node/node.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L26">basic-node/node.ts:26</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -181,7 +181,7 @@
 					<div class="tsd-signature tsd-kind-icon">check<wbr>Value<wbr>Equality<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L28">basic-node/node.ts:28</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L28">basic-node/node.ts:28</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -220,7 +220,7 @@
 					<div class="tsd-signature tsd-kind-icon">compare<wbr>Keys<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L22">basic-node/node.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L22">basic-node/node.ts:22</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -259,7 +259,7 @@
 					<div class="tsd-signature tsd-kind-icon">compare<wbr>Values<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L24">basic-node/node.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L24">basic-node/node.ts:24</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -298,7 +298,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<wbr>Bool<wbr>From<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L12">basic-node/node.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L12">basic-node/node.ts:12</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -334,7 +334,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<wbr>Compare<wbr>Keys<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L14">basic-node/node.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L14">basic-node/node.ts:14</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -370,7 +370,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<wbr>Equality<wbr>Bounds<wbr>Fn<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L20">basic-node/node.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L20">basic-node/node.ts:20</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -406,7 +406,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<wbr>Lower<wbr>Bounds<wbr>Fn<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L16">basic-node/node.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L16">basic-node/node.ts:16</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -442,7 +442,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<wbr>Upper<wbr>Bounds<wbr>Fn<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/basic-node/node.ts#L18">basic-node/node.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/basic-node/node.ts#L18">basic-node/node.ts:18</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules/_btreeutils_.html
+++ b/docs/modules/_btreeutils_.html
@@ -97,7 +97,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/bTreeUtils.ts#L141">bTreeUtils.ts:141</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/bTreeUtils.ts#L141">bTreeUtils.ts:141</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -127,7 +127,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/bTreeUtils.ts#L126">bTreeUtils.ts:126</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/bTreeUtils.ts#L126">bTreeUtils.ts:126</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -156,7 +156,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/bTreeUtils.ts#L92">bTreeUtils.ts:92</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/bTreeUtils.ts#L92">bTreeUtils.ts:92</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -187,7 +187,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/bTreeUtils.ts#L102">bTreeUtils.ts:102</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/bTreeUtils.ts#L102">bTreeUtils.ts:102</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -218,7 +218,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/bTreeUtils.ts#L44">bTreeUtils.ts:44</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/bTreeUtils.ts#L44">bTreeUtils.ts:44</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -253,7 +253,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/bTreeUtils.ts#L66">bTreeUtils.ts:66</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/bTreeUtils.ts#L66">bTreeUtils.ts:66</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -288,7 +288,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/bTreeUtils.ts#L26">bTreeUtils.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/bTreeUtils.ts#L26">bTreeUtils.ts:26</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -316,7 +316,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/bTreeUtils.ts#L112">bTreeUtils.ts:112</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/bTreeUtils.ts#L112">bTreeUtils.ts:112</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -345,7 +345,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/a1ba25a/src/bTreeUtils.ts#L6">bTreeUtils.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/marcusjwhelan/binary-type-tree/blob/99d52f2/src/bTreeUtils.ts#L6">bTreeUtils.ts:6</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binary-type-tree",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Binary Trees written in TypeScript",
   "main": "lib/index.js",
   "scripts": {

--- a/src/avl-node/avl.ts
+++ b/src/avl-node/avl.ts
@@ -440,7 +440,6 @@ export class AVLNode extends Node<AVLNode> implements IAVLNode {
             const arg1 = selfOfLoop.left ? selfOfLoop.left.height : 0;
             const arg2 = selfOfLoop.right ? selfOfLoop.right.height : 0;
             selfOfLoop.height = 1 + Math.max(arg1, arg2);
-
             if (selfOfLoop.balanceFactor() > 1) {
                 rotated = selfOfLoop.rightTooSmall();
                 if (i === 0) {

--- a/src/basic-node/node.ts
+++ b/src/basic-node/node.ts
@@ -157,9 +157,17 @@ export abstract class Node<T> implements INode<T> {
      * @param options
      */
     protected constructor( public options: INodeConstructor<Node<T>> ) {
-        this.key = options.key || null;
+        if (options.hasOwnProperty("key") && options.key !== undefined) {
+            this.key = options.key;
+        } else {
+            this.key = null;
+        }
+        if (options.hasOwnProperty("value") && options.value !== undefined) {
+            this.value = options.value;
+        } else {
+            this.value = [null];
+        }
         this.parent = options.parent || null;
-        this.value = options.value ? options.value : [null];
         this.unique = options.unique || false;
         this.compareKeys = options.compareKeys || bTreeUtils.defaultCompareKeysFunction;
         this.compareValues = options.compareValues || bTreeUtils.defaultCompareValues;


### PR DESCRIPTION
__Change Log:__ 
=

* Bug Fix 
When creating a node if the key was falsy it was set to null. This meant any key that was false or 0 would in turn be set to null, including the same for the value. Instead only set to null if undefined or none existent.
* Version bump 1.0.5 to 1.0.6